### PR TITLE
Build fix for GCC 5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ unpack_source $(basename $NEWLIB_SRC)
 #unpack_source $(basename $INSIGHT_SRC)
 # Patch for texinfo5. Adapted from Marcello Pogliani
 patch -p1 < ../gcc-texinfo5.patch
+patch -p1 < ../fix-gcc5-build.patch
 )
 
 # Set the PATH to include the binaries we're going to build.

--- a/fix-gcc5-build.patch
+++ b/fix-gcc5-build.patch
@@ -1,0 +1,22 @@
+--- src/gcc-4.5.2/gcc/cp/cfns.h.orig	2015-02-13 08:27:46.000000000 +0200
++++ src/gcc-4.5.2/gcc/cp/cfns.h	2015-02-13 10:23:53.000000000 +0200
+@@ -53,6 +53,9 @@
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+@@ -96,7 +99,7 @@
+       400, 400, 400, 400, 400, 400, 400, 400, 400, 400,
+       400, 400, 400, 400, 400, 400, 400
+     };
+-  register int hval = len;
++  register int hval = (int)len;
+ 
+   switch (hval)
+     {
+


### PR DESCRIPTION
When using GCC > 5 to compile GCC 4.5.2 we got this error:

```
In file included from /mnt/mobile/osmocom/toolchain/axilirator/src/gcc-4.5.2/gcc/cp/except.c:927:0:
cfns.gperf: At top level:
cfns.gperf:101:1: error: ‘gnu_inline’ attribute present on ‘libc_name_p’
cfns.gperf:26:14: error: but not here
Makefile:1047: recipe for target 'cp/except.o' failed
make[1]: *** [cp/except.o] Error 1
make[1]: Leaving directory '/mnt/mobile/osmocom/toolchain/axilirator/build/gcc-4.5.2/gcc'
Makefile:5024: recipe for target 'all-gcc' failed
make: *** [all-gcc] Error 2
```

This patch fixes it.
Got patch from there: https://github.com/DragonFlyBSD/DPorts/issues/136
